### PR TITLE
Always return longs from decoded integers

### DIFF
--- a/src/clj_cbor/codec.clj
+++ b/src/clj_cbor/codec.clj
@@ -165,7 +165,7 @@
   "Writes an integer value."
   [encoder ^DataOutputStream out n]
   (if (neg? n)
-    (header/write out :negative-integer (- -1 n))
+    (header/write out :negative-integer (-' -1 n))
     (header/write out :unsigned-integer n)))
 
 

--- a/src/clj_cbor/header.clj
+++ b/src/clj_cbor/header.clj
@@ -133,9 +133,9 @@
     info
     ; Otherwise, signify the number of bytes following.
     (case info
-      24 (.readUnsignedByte input)
-      25 (.readUnsignedShort input)
-      26 (bit-and (.readInt input) 0xFFFFFFFF)
+      24 (long (.readUnsignedByte input))
+      25 (long (.readUnsignedShort input))
+      26 (long (bit-and (.readInt input) 0xFFFFFFFF))
       27 (read-unsigned-long input)
       (28 29 30)
         (error/*handler*


### PR DESCRIPTION
Fixes #4.