### PR TITLE
Directly coerce to DataOutputStream without using output-stream

### DIFF
--- a/src/clj_cbor/core.clj
+++ b/src/clj_cbor/core.clj
@@ -78,15 +78,6 @@
 
 ;; ## Encoding Functions
 
-(defn- data-output-stream
-  "Coerce the argument to a `DataOutputStream`."
-  ^DataOutputStream
-  [input]
-  (if (instance? DataOutputStream input)
-    input
-    (DataOutputStream. (io/output-stream input))))
-
-
 (defn encode
   "Encode a single value as CBOR data.
 
@@ -97,11 +88,11 @@
    (encode default-codec value))
   ([encoder value]
    (let [buffer (ByteArrayOutputStream.)]
-     (with-open [output (data-output-stream buffer)]
+     (with-open [output (DataOutputStream. buffer)]
        (encode encoder output value))
      (.toByteArray buffer)))
   ([encoder ^OutputStream output value]
-   (let [data-output (data-output-stream output)]
+   (let [data-output (DataOutputStream. output)]
      (codec/write-value encoder data-output value))))
 
 
@@ -116,11 +107,11 @@
    (encode-seq default-codec values))
   ([encoder values]
    (let [buffer (ByteArrayOutputStream.)]
-     (with-open [output (data-output-stream buffer)]
+     (with-open [output (DataOutputStream. buffer)]
        (encode-seq encoder output values))
      (.toByteArray buffer)))
   ([encoder ^OutputStream output values]
-   (let [data-output (data-output-stream output)]
+   (let [data-output (DataOutputStream. output)]
      (transduce (map (partial encode encoder data-output)) + 0 values))))
 
 

--- a/src/clj_cbor/core.clj
+++ b/src/clj_cbor/core.clj
@@ -78,6 +78,15 @@
 
 ;; ## Encoding Functions
 
+(defn- data-output-stream
+  "Coerce the argument to a `DataOutputStream`."
+  ^DataOutputStream
+  [^OutputStream input]
+  (cond-> input
+
+    (not (instance? DataOutputStream input))
+    (DataOutputStream.)))
+
 (defn encode
   "Encode a single value as CBOR data.
 
@@ -92,7 +101,7 @@
        (encode encoder output value))
      (.toByteArray buffer)))
   ([encoder ^OutputStream output value]
-   (let [data-output (DataOutputStream. output)]
+   (let [data-output (data-output-stream output)]
      (codec/write-value encoder data-output value))))
 
 
@@ -111,7 +120,7 @@
        (encode-seq encoder output values))
      (.toByteArray buffer)))
   ([encoder ^OutputStream output values]
-   (let [data-output (DataOutputStream. output)]
+   (let [data-output (data-output-stream output)]
      (transduce (map (partial encode encoder data-output)) + 0 values))))
 
 


### PR DESCRIPTION
This is problematic because io/output-stream in clojure adds yet an
other buffer in the middle which is uncessary since all instances in the
code are OutputStream already and DataOutputStream already accepts it,
secondly it creates corruption while using different streams like
GZIPOutputStream for unknown reasons the BufferedOutputStream introduced
by io/output-stream is preventing the last flush thus corrupting the
output.

To reproduce the bug try this:

```
> (with-open [fd (->> "myfile.cbor.gz" (clojure.java.io/output-stream) (java.util.zip.GZIPOutputStream.))] (clj-cbor.core/encode clj-cbor.core/default-codec fd (into [] (range 1e6))))    
4868653                                                                                                                      
> (with-open [fd (->> "myfile.cbor.gz" (clojure.java.io/input-stream) (java.util.zip.GZIPInputStream.))] (doall (clj-cbor.core/decode clj-cbor.core/default-codec fd)))                    
                                                                                                                             
Execution error (ExceptionInfo) at clj-cbor.error/codec-exception! (error.clj:8).                                            
Input data ended while parsing a CBOR value.
```

The code above works if we do:

```
(with-open [fd (->> "myfile.cbor.gz" (clojure.java.io/output-stream) (java.util.zip.GZIPOutputStream.) (java.io.DataOutputStream.))] (clj-cbor.core/encode clj-cbor.core/default-codec fd
(into [] (range 1e6))))
```

As you can see we directly provide ourself the `DataOutputStream` thus in the code above we don't call io/output-stream as explained.