### PR TITLE
Report type when erroring on unsupported-type

### DIFF
--- a/src/clj_cbor/codec.clj
+++ b/src/clj_cbor/codec.clj
@@ -923,7 +923,7 @@
           ::unsupported-type
           (str "No known encoding for object: " (pr-str x))
           {:value x 
-           :type (type x})))
+           :type (type x)})))
 
 
   Decoder

--- a/src/clj_cbor/codec.clj
+++ b/src/clj_cbor/codec.clj
@@ -922,7 +922,8 @@
         (error/*handler*
           ::unsupported-type
           (str "No known encoding for object: " (pr-str x))
-          {:value x})))
+          {:value x 
+           :type (type x})))
 
 
   Decoder


### PR DESCRIPTION
When logging the value, it's not always clear the exact type that's causing failure (`ArrayList` vs `vec` for example). Adding the type makes this error message a little more informative. 